### PR TITLE
remove unnecessary docblocks

### DIFF
--- a/src/Phalcon/cache/backend/Mongo.php
+++ b/src/Phalcon/cache/backend/Mongo.php
@@ -132,7 +132,6 @@ class Mongo extends \Phalcon\Cache\Backend
      *
      * @param mixed $keyName
      * @param int $value
-     * @param int|string $$keyName
      * @return int|null
      */
     public function decrement($keyName, $value = 1) {}

--- a/src/Phalcon/cli/Dispatcher.php
+++ b/src/Phalcon/cli/Dispatcher.php
@@ -116,9 +116,6 @@ class Dispatcher extends \Phalcon\Dispatcher implements \Phalcon\Cli\DispatcherI
      * @param mixed $option
      * @param mixed $filters
      * @param mixed $defaultValue
-     * @param mixed $$option
-     * @param string|array $$filters
-     * @param mixed $$defaultValue
      * @return mixed
      */
     public function getOption($option, $filters = null, $defaultValue = null) {}

--- a/src/Phalcon/forms/element/Numeric.php
+++ b/src/Phalcon/forms/element/Numeric.php
@@ -14,7 +14,6 @@ class Numeric extends \Phalcon\Forms\Element
      * Renders the element widget returning html
      *
      * @param mixed $attributes
-     * @param array $$attributes
      * @return string
      */
     public function render($attributes = null) {}

--- a/src/Phalcon/forms/element/Password.php
+++ b/src/Phalcon/forms/element/Password.php
@@ -14,7 +14,6 @@ class Password extends \Phalcon\Forms\Element
      * Renders the element widget returning html
      *
      * @param mixed $attributes
-     * @param array $$attributes
      * @return string
      */
     public function render($attributes = null) {}

--- a/src/Phalcon/image/Adapter.php
+++ b/src/Phalcon/image/Adapter.php
@@ -105,10 +105,6 @@ abstract class Adapter implements \Phalcon\Image\AdapterInterface
      * @param int $height
      * @param int $deltaX
      * @param int $rigidity
-     * @param int $$width new width
-     * @param int $$height new height
-     * @param int $$deltaX How much the seam can traverse on x-axis. Passing 0 causes the seams to be straight.
-     * @param int $$rigidity Introduces a bias for non-straight seams. This parameter is typically 0.
      * @return Adapter
      */
     public function liquidRescale($width, $height, $deltaX = 0, $rigidity = 0) {}

--- a/src/Phalcon/image/adapter/Imagick.php
+++ b/src/Phalcon/image/adapter/Imagick.php
@@ -57,10 +57,6 @@ class Imagick extends \Phalcon\Image\Adapter
      * @param int $height
      * @param int $deltaX
      * @param int $rigidity
-     * @param int $$width new width
-     * @param int $$height new height
-     * @param int $$deltaX How much the seam can traverse on x-axis. Passing 0 causes the seams to be straight.
-     * @param int $$rigidity Introduces a bias for non-straight seams. This parameter is typically 0.
      */
     protected function _liquidRescale($width, $height, $deltaX, $rigidity) {}
 
@@ -150,7 +146,6 @@ class Imagick extends \Phalcon\Image\Adapter
      * Blur image
      *
      * @param int $radius
-     * @param int $$radius Blur radius
      */
     protected function _blur($radius) {}
 
@@ -158,7 +153,6 @@ class Imagick extends \Phalcon\Image\Adapter
      * Pixelate image
      *
      * @param int $amount
-     * @param int $$amount amount to pixelate
      */
     protected function _pixelate($amount) {}
 

--- a/src/Phalcon/logger/Formatter.php
+++ b/src/Phalcon/logger/Formatter.php
@@ -24,8 +24,6 @@ abstract class Formatter implements \Phalcon\Logger\FormatterInterface
      * @see http://www.php-fig.org/psr/psr-3/ Section 1.2 Message
      * @param string $message
      * @param mixed $context
-     * @param string $$message
-     * @param array $$context
      */
     public function interpolate($message, $context = null) {}
 

--- a/src/Phalcon/logger/FormatterInterface.php
+++ b/src/Phalcon/logger/FormatterInterface.php
@@ -17,7 +17,6 @@ interface FormatterInterface
      * @param int $type
      * @param int $timestamp
      * @param mixed $context
-     * @param array $$context
      * @return string|array
      */
     public function format($message, $type, $timestamp, $context = null);

--- a/src/Phalcon/logger/Item.php
+++ b/src/Phalcon/logger/Item.php
@@ -65,10 +65,6 @@ class Item
      * @param int $type
      * @param int $time
      * @param mixed $context
-     * @param string $$message
-     * @param integer $$type
-     * @param integer $$time
-     * @param array $$context
      */
     public function __construct($message, $type, $time = 0, $context = null) {}
 

--- a/src/Phalcon/logger/formatter/Firephp.php
+++ b/src/Phalcon/logger/formatter/Firephp.php
@@ -65,9 +65,6 @@ class Firephp extends \Phalcon\Logger\Formatter
      * @param int $type
      * @param int $timestamp
      * @param mixed $context
-     * @param string $$message
-     * @param int $$type
-     * @param int $$timestamp
      * @return string
      */
     public function format($message, $type, $timestamp, $context = null) {}

--- a/src/Phalcon/logger/formatter/Json.php
+++ b/src/Phalcon/logger/formatter/Json.php
@@ -17,7 +17,6 @@ class Json extends \Phalcon\Logger\Formatter
      * @param int $type
      * @param int $timestamp
      * @param mixed $context
-     * @param array $$context
      * @return string
      */
     public function format($message, $type, $timestamp, $context = null) {}

--- a/src/Phalcon/logger/formatter/Line.php
+++ b/src/Phalcon/logger/formatter/Line.php
@@ -67,7 +67,6 @@ class Line extends \Phalcon\Logger\Formatter
      * @param int $type
      * @param int $timestamp
      * @param mixed $context
-     * @param array $$context
      * @return string
      */
     public function format($message, $type, $timestamp, $context = null) {}

--- a/src/Phalcon/mvc/Micro.php
+++ b/src/Phalcon/mvc/Micro.php
@@ -110,8 +110,6 @@ class Micro extends \Phalcon\Di\Injectable implements \ArrayAccess
      *
      * @param string $routePattern
      * @param mixed $handler
-     * @param string $$routePattern
-     * @param callable $$handler
      * @return \Phalcon\Mvc\Router\RouteInterface
      */
     public function put($routePattern, $handler) {}
@@ -121,8 +119,6 @@ class Micro extends \Phalcon\Di\Injectable implements \ArrayAccess
      *
      * @param string $routePattern
      * @param mixed $handler
-     * @param string $$routePattern
-     * @param callable $$handler
      * @return \Phalcon\Mvc\Router\RouteInterface
      */
     public function patch($routePattern, $handler) {}

--- a/src/Phalcon/mvc/Model.php
+++ b/src/Phalcon/mvc/Model.php
@@ -404,7 +404,6 @@ abstract class Model implements \Phalcon\Mvc\EntityInterface, \Phalcon\Mvc\Model
      * @param ModelInterface $base
      * @param array $data
      * @param int $dirtyState
-     * @param \Phalcon\Mvc\ModelInterface $$base
      * @return \Phalcon\Mvc\ModelInterface
      */
     public static function cloneResult(ModelInterface $base, array $data, $dirtyState = 0) {}
@@ -1597,7 +1596,6 @@ abstract class Model implements \Phalcon\Mvc\EntityInterface, \Phalcon\Mvc\Model
      * </code>
      *
      * @param mixed $columns
-     * @param array $$columns
      * @return array
      */
     public function toArray($columns = null) {}

--- a/src/Phalcon/mvc/UrlInterface.php
+++ b/src/Phalcon/mvc/UrlInterface.php
@@ -44,7 +44,6 @@ interface UrlInterface
      * @param string|array $uri
      * @param array|object $args Optional arguments to be appended to the query string
      * @param bool $local
-     * @param bool $$local
      * @return string
      */
     public function get($uri = null, $args = null, $local = null);

--- a/src/Phalcon/mvc/View.php
+++ b/src/Phalcon/mvc/View.php
@@ -443,7 +443,6 @@ class View extends \Phalcon\Di\Injectable implements \Phalcon\Mvc\ViewInterface
      * @param boolean $silence
      * @param boolean $mustClean
      * @param \Phalcon\Cache\BackendInterface $cache
-     * @param \Phalcon\Cache\BackendInterface $$cache
      */
     protected function _engineRender($engines, $viewPath, $silence, $mustClean, \Phalcon\Cache\BackendInterface $cache = null) {}
 

--- a/src/Phalcon/mvc/collection/Manager.php
+++ b/src/Phalcon/mvc/collection/Manager.php
@@ -163,7 +163,6 @@ class Manager implements \Phalcon\Di\InjectionAwareInterface, \Phalcon\Events\Ev
      * Returns the connection related to a model
      *
      * @param \Phalcon\Mvc\CollectionInterface $model
-     * @param \Phalcon\Mvc\CollectionInterface $$model
      * @return \Mongo
      */
     public function getConnection(\Phalcon\Mvc\CollectionInterface $model) {}

--- a/src/Phalcon/mvc/model/ManagerInterface.php
+++ b/src/Phalcon/mvc/model/ManagerInterface.php
@@ -141,7 +141,6 @@ interface ManagerInterface
      * @param mixed $referencedModel
      * @param mixed $referencedFields
      * @param mixed $options
-     * @param \Phalcon\Mvc\ModelInterface $$model
      * @return \Phalcon\Mvc\Model\RelationInterface
      */
     public function addHasOne(\Phalcon\Mvc\ModelInterface $model, $fields, $referencedModel, $referencedFields, $options = null);
@@ -218,11 +217,6 @@ interface ManagerInterface
      * @param mixed $modelRelation
      * @param \Phalcon\Mvc\ModelInterface $record
      * @param mixed $parameters
-     * @param string $$method
-     * @param string $$modelName
-     * @param string $$modelRelation
-     * @param \Phalcon\Mvc\Model $$record
-     * @param array $$parameters
      * @return \Phalcon\Mvc\Model\ResultsetInterface
      */
     public function getBelongsToRecords($method, $modelName, $modelRelation, \Phalcon\Mvc\ModelInterface $record, $parameters = null);
@@ -235,11 +229,6 @@ interface ManagerInterface
      * @param mixed $modelRelation
      * @param \Phalcon\Mvc\ModelInterface $record
      * @param mixed $parameters
-     * @param string $$method
-     * @param string $$modelName
-     * @param string $$modelRelation
-     * @param \Phalcon\Mvc\Model $$record
-     * @param array $$parameters
      * @return \Phalcon\Mvc\Model\ResultsetInterface
      */
     public function getHasManyRecords($method, $modelName, $modelRelation, \Phalcon\Mvc\ModelInterface $record, $parameters = null);
@@ -252,11 +241,6 @@ interface ManagerInterface
      * @param mixed $modelRelation
      * @param \Phalcon\Mvc\ModelInterface $record
      * @param mixed $parameters
-     * @param string $$method
-     * @param string $$modelName
-     * @param string $$modelRelation
-     * @param \Phalcon\Mvc\Model $$record
-     * @param array $$parameters
      * @return \Phalcon\Mvc\Model\ResultsetInterface
      */
     public function getHasOneRecords($method, $modelName, $modelRelation, \Phalcon\Mvc\ModelInterface $record, $parameters = null);
@@ -265,7 +249,6 @@ interface ManagerInterface
      * Gets belongsTo relations defined on a model
      *
      * @param \Phalcon\Mvc\ModelInterface $model
-     * @param \Phalcon\Mvc\ModelInterface $$model
      * @return array
      */
     public function getBelongsTo(\Phalcon\Mvc\ModelInterface $model);
@@ -274,7 +257,6 @@ interface ManagerInterface
      * Gets hasMany relations defined on a model
      *
      * @param \Phalcon\Mvc\ModelInterface $model
-     * @param \Phalcon\Mvc\ModelInterface $$model
      * @return array
      */
     public function getHasMany(\Phalcon\Mvc\ModelInterface $model);
@@ -283,7 +265,6 @@ interface ManagerInterface
      * Gets hasOne relations defined on a model
      *
      * @param \Phalcon\Mvc\ModelInterface $model
-     * @param \Phalcon\Mvc\ModelInterface $$model
      * @return array
      */
     public function getHasOne(\Phalcon\Mvc\ModelInterface $model);
@@ -292,7 +273,6 @@ interface ManagerInterface
      * Gets hasOne relations defined on a model
      *
      * @param \Phalcon\Mvc\ModelInterface $model
-     * @param \Phalcon\Mvc\ModelInterface $$model
      * @return array
      */
     public function getHasOneAndHasMany(\Phalcon\Mvc\ModelInterface $model);
@@ -301,7 +281,6 @@ interface ManagerInterface
      * Query all the relationships defined on a model
      *
      * @param mixed $modelName
-     * @param string $$modelName
      * @return \Phalcon\Mvc\Model\RelationInterface[]
      */
     public function getRelations($modelName);
@@ -311,8 +290,6 @@ interface ManagerInterface
      *
      * @param mixed $first
      * @param mixed $second
-     * @param string $$first
-     * @param string $$second
      * @return array
      */
     public function getRelationsBetween($first, $second);
@@ -321,7 +298,6 @@ interface ManagerInterface
      * Creates a Phalcon\Mvc\Model\Query without execute it
      *
      * @param mixed $phql
-     * @param string $$phql
      * @return \Phalcon\Mvc\Model\QueryInterface
      */
     public function createQuery($phql);
@@ -331,8 +307,6 @@ interface ManagerInterface
      *
      * @param mixed $phql
      * @param mixed $placeholders
-     * @param string $$phql
-     * @param array $$placeholders
      * @return \Phalcon\Mvc\Model\QueryInterface
      */
     public function executeQuery($phql, $placeholders = null);
@@ -341,7 +315,6 @@ interface ManagerInterface
      * Creates a Phalcon\Mvc\Model\Query\Builder
      *
      * @param mixed $params
-     * @param string $$params
      * @return \Phalcon\Mvc\Model\Query\BuilderInterface
      */
     public function createBuilder($params = null);
@@ -360,7 +333,6 @@ interface ManagerInterface
      *
      * @param mixed $eventName
      * @param \Phalcon\Mvc\ModelInterface $model
-     * @param string $$eventName
      */
     public function notifyEvent($eventName, \Phalcon\Mvc\ModelInterface $model);
 
@@ -372,8 +344,6 @@ interface ManagerInterface
      * @param \Phalcon\Mvc\ModelInterface $model
      * @param mixed $eventName
      * @param mixed $data
-     * @param string $$eventName
-     * @param array $$data
      * @return boolean
      */
     public function missingMethod(\Phalcon\Mvc\ModelInterface $model, $eventName, $data);
@@ -390,8 +360,6 @@ interface ManagerInterface
      *
      * @param string $modelName
      * @param string $alias
-     * @param string $$modelName
-     * @param string $$alias
      * @return \Phalcon\Mvc\Model\Relation
      */
     public function getRelationByAlias($modelName, $alias);

--- a/src/Phalcon/mvc/model/Query.php
+++ b/src/Phalcon/mvc/model/Query.php
@@ -299,7 +299,6 @@ class Query implements \Phalcon\Mvc\Model\QueryInterface, \Phalcon\Di\InjectionA
      * Returns a processed order clause for a SELECT statement
      *
      * @param mixed $order
-     * @param array|string $$order
      * @return array
      */
     protected final function _getOrderClause($order) {}

--- a/src/Phalcon/mvc/model/Row.php
+++ b/src/Phalcon/mvc/model/Row.php
@@ -23,7 +23,6 @@ class Row implements \Phalcon\Mvc\EntityInterface, \Phalcon\Mvc\Model\ResultInte
      * Checks whether offset exists in the row
      *
      * @param mixed $index
-     * @param string|int $$index
      * @return bool
      */
     public function offsetExists($index) {}


### PR DESCRIPTION
There are a lot of docblock parameters starting with `$$`.  But
* it is not a part of the spec
* they are always duplicates (thus redundant)
* IDE goes crazy and screams a warning (see screenshot) 
![default](https://user-images.githubusercontent.com/919655/36123952-b2bbf0a8-104e-11e8-85e0-3878a0bee39e.png)
