### PR TITLE
Composer minimum version & InjectionAwareInterface type hint 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,6 @@
         "forum": "https://forum.phalconphp.com/"
     },
     "require": {
-        "php": ">=5.3.0"
+        "php": ">=7.2.0"
     }
 }

--- a/src/Phalcon/di/InjectionAwareInterface.php
+++ b/src/Phalcon/di/InjectionAwareInterface.php
@@ -14,14 +14,15 @@ interface InjectionAwareInterface
      * Sets the dependency injector
      *
      * @param \Phalcon\DiInterface $dependencyInjector
+     * @return void
      */
-    public function setDI(\Phalcon\DiInterface $dependencyInjector);
+    public function setDI(\Phalcon\DiInterface $dependencyInjector) : void;
 
     /**
      * Returns the internal dependency injector
      *
-     * @return null|\Phalcon\DiInterface
+     * @return \Phalcon\DiInterface
      */
-    public function getDI();
+    public function getDI() : \Phalcon\DiInterface;
 
 }


### PR DESCRIPTION
Phalcon require minimum PHP 7.2 & is strict type hint ; fix InjectionAwareInterface