### PR TITLE
Fixed missing \ in extended Exception.

### DIFF
--- a/src/Phalcon/Exception.php
+++ b/src/Phalcon/Exception.php
@@ -7,7 +7,7 @@ namespace Phalcon;
  *
  * All framework exceptions should use or extend this exception
  */
-class Exception extends Exception implements \Throwable
+class Exception extends \Exception implements \Throwable
 {
 
     /**

--- a/src/Phalcon/cache/exception/Exception.php
+++ b/src/Phalcon/cache/exception/Exception.php
@@ -5,7 +5,7 @@ namespace Phalcon\Cache\Exception;
 /**
  * Exceptions thrown in Phalcon\Cache will use this class
  */
-class Exception extends Exception implements \Psr\SimpleCache\CacheException
+class Exception extends \Exception implements \Psr\SimpleCache\CacheException
 {
 
 }

--- a/src/Phalcon/cache/exception/InvalidArgumentException.php
+++ b/src/Phalcon/cache/exception/InvalidArgumentException.php
@@ -5,7 +5,7 @@ namespace Phalcon\Cache\Exception;
 /**
  * Exceptions thrown in Phalcon\Cache will use this class
  */
-class InvalidArgumentException extends Exception implements \Psr\SimpleCache\InvalidArgumentException
+class InvalidArgumentException extends \Exception implements \Psr\SimpleCache\InvalidArgumentException
 {
 
 }

--- a/src/Phalcon/collection/Exception.php
+++ b/src/Phalcon/collection/Exception.php
@@ -5,7 +5,7 @@ namespace Phalcon\Collection;
 /**
  * Exceptions for the Collection object
  */
-class Exception extends Exception implements \Throwable
+class Exception extends \Exception implements \Throwable
 {
 
 }


### PR DESCRIPTION
Workaround for https://github.com/phalcon/zephir/issues/1907