### PR TITLE
Add return type annotation to Config::path() method

### DIFF
--- a/src/Phalcon/Config.php
+++ b/src/Phalcon/Config.php
@@ -86,6 +86,7 @@ class Config extends Collection
      * @param string $path
      * @param mixed $defaultValue
      * @param mixed $delimiter
+     * @return mixed
      */
     public function path(string $path, $defaultValue = null, $delimiter = null)
     {


### PR DESCRIPTION
PHPStorm says return type of `Config::path()` is `void` because there is no return type annotation.
So, I added it.

<img width="613" alt="Screen Shot 2020-03-21 at 18 12 06" src="https://user-images.githubusercontent.com/4360656/77223472-4680b180-6ba0-11ea-86a5-c92dad810a98.png">
