### PR TITLE
ServiceProviderInterface add return type

### DIFF
--- a/src/Phalcon/Di/ServiceProviderInterface.php
+++ b/src/Phalcon/Di/ServiceProviderInterface.php
@@ -42,5 +42,5 @@ interface ServiceProviderInterface
      * @param DiInterface $di
      * @return void
      */
-    public function register(DiInterface $di);
+    public function register(DiInterface $di): void;
 }


### PR DESCRIPTION
I added it because an error will occur if you do not write the return value.