### PR TITLE
Add return type Item::getContext() back again

### DIFF
--- a/src/Phalcon/Logger/Item.php
+++ b/src/Phalcon/Logger/Item.php
@@ -19,7 +19,7 @@ class Item
     /**
      * Log Context
      *
-     * @return mixed
+     * @var mixed
      */
     protected $context;
 
@@ -54,6 +54,8 @@ class Item
 
     /**
      * Log Context
+     *
+     * @return mixed
      */
     public function getContext()
     {


### PR DESCRIPTION
`Item::getContext()` has no return type defined and the `$context` property has a `@return` anntotation instead of `@var`.

This was originally added in SHA: dfda9a88ec4de4f692fa5e1d976ec9083d9aa643
but somehow removed in 62065fd2c5ad09633d17ab8d97b6b11fa94d5771

----
If the Stubs are autogenerated: I think the documentation of https://github.com/phalcon/cphalcon/blob/v4.0.6/phalcon/Logger/Item.zep should be fixed too?