### PR TITLE
update findFirst return types

### DIFF
--- a/src/Phalcon/Mvc/Model.php
+++ b/src/Phalcon/Mvc/Model.php
@@ -788,9 +788,9 @@ abstract class Model extends AbstractInjectionAware implements \Phalcon\Mvc\Enti
      *     ],
      *     'hydration' => null
      * ]
-     * @return bool|\Phalcon\Mvc\ModelInterface
+     * @return null|\Phalcon\Mvc\ModelInterface
      */
-    public static function findFirst($parameters = null)
+    public static function findFirst($parameters = null): null
     {
     }
 

--- a/src/Phalcon/Mvc/Model.php
+++ b/src/Phalcon/Mvc/Model.php
@@ -790,7 +790,7 @@ abstract class Model extends AbstractInjectionAware implements \Phalcon\Mvc\Enti
      * ]
      * @return null|\Phalcon\Mvc\ModelInterface
      */
-    public static function findFirst($parameters = null): null
+    public static function findFirst($parameters = null): ?\Phalcon\Mvc\ModelInterface
     {
     }
 


### PR DESCRIPTION
This change is a patch until the v4.1 release.
The findFirst method returns null instead of bool from v4.
I know this change disappears in 4.1, but programming in the IDE in 4.0
I want you to change it because it is confusing.