### PR TITLE
add count method support

### DIFF
--- a/src/Mvc/Model/Resultset/Simple.php
+++ b/src/Mvc/Model/Resultset/Simple.php
@@ -110,4 +110,9 @@ class Simple extends Resultset
     public function __unserialize(array $data): void
     {
     }
+    
+    /**
+    * @return int
+    */
+    public function count(): int
 }


### PR DESCRIPTION
vscode intelliphense show error for count method not found
for example:

$subscription_type = 'VIP';
$rows = Account::find([
    'conditions' => 'subscription_type = :type:',
    'bind' => [ 'type' => $subscription_type ]
]);
$items_count = $rows->count(); // count() calling showing error