### PR TITLE
Added return type to getReusableRecords

### DIFF
--- a/src/Mvc/Model/Manager.php
+++ b/src/Mvc/Model/Manager.php
@@ -724,6 +724,8 @@ class Manager implements \Phalcon\Mvc\Model\ManagerInterface, \Phalcon\Di\Inject
      *
      * @param string $modelName
      * @param string $key
+     *
+     * @return mixed
      */
     public function getReusableRecords(string $modelName, string $key)
     {


### PR DESCRIPTION
The Method getReusableRecords() is not a void method and returns a value of an array so I added a return type in the method comments, because in PHP 7.4 you can't return mixed.