### PR TITLE
Fix: PUT documentation

### DIFF
--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -446,13 +446,13 @@ class Request extends AbstractInjectionAware implements \Phalcon\Http\RequestInt
     }
 
     /**
-     * Gets a variable from put request
+     * Gets a variable from the PUT request
      *
      * ```php
-     * // Returns value from $_PUT["user_email"] without sanitizing
+     * // Returns value from PUT stream without sanitizing
      * $userEmail = $request->getPut("user_email");
      *
-     * // Returns value from $_PUT["user_email"] with sanitizing
+     * // Returns value from PUT stream with sanitizing
      * $userEmail = $request->getPut("user_email", "email");
      * ```
      *

--- a/src/Http/RequestInterface.php
+++ b/src/Http/RequestInterface.php
@@ -258,13 +258,13 @@ interface RequestInterface
     public function getPost(string $name = null, $filters = null, $defaultValue = null, bool $notAllowEmpty = false, bool $noRecursive = false): mixed;
 
     /**
-     * Gets a variable from put request
+     * Gets a variable from the PUT request
      *
      * ```php
-     * // Returns value from $_PUT["user_email"] without sanitizing
+     * // Returns value from PUT stream without sanitizing
      * $userEmail = $request->getPut("user_email");
      *
-     * // Returns value from $_PUT["user_email"] with sanitizing
+     * // Returns value from PUT stream with sanitizing
      * $userEmail = $request->getPut("user_email", "email");
      * ```
      *


### PR DESCRIPTION
There is no `$_PUT` superglobal in PHP.

Existing docs refer to it as `PUT` stream:
- https://docs.phalcon.io/4.2/request/#put